### PR TITLE
test(docs): add module coverage kickoff docs

### DIFF
--- a/docs/event-test-kickoff.md
+++ b/docs/event-test-kickoff.md
@@ -1,0 +1,151 @@
+# Event Test Kickoff
+
+This document is the starting point for the `event` module test pass.
+
+## Current State
+
+- There are no event module tests in the current tree.
+- The event module has two controllers and two services:
+  - `src/main/java/com/ht/eventbox/modules/event/EventController.java`
+  - `src/main/java/com/ht/eventbox/modules/event/VoucherController.java`
+  - `src/main/java/com/ht/eventbox/modules/event/EventService.java`
+  - `src/main/java/com/ht/eventbox/modules/event/VoucherService.java`
+
+## Recommended Test Order
+
+1. `EventServiceTests`
+2. `EventControllerTests`
+3. `VoucherServiceTests`
+4. `VoucherControllerTests`
+
+Service tests should come first because the event service contains the branching logic, authorization checks, and side effects. Controller tests can stay thin and focus on request mapping, status codes, and response payloads.
+
+## First Event Service Targets
+
+Start with the highest-risk paths in `EventService`:
+
+- `getById`
+- `getDiscovery`
+- `search`
+- `create`
+- `update`
+- `publishByAdmin`
+- `archiveByAdmin`
+- `archive`
+- `inactive`
+- `active`
+- `updateTags`
+- `getByIdAndStatusIsNot`
+- `getWithRealStockByIdAndStatusIsNot`
+- `getAllByStatusIn`
+- `eventPayout`
+- `isMember`
+
+Suggested first assertions:
+
+- missing event returns `EVENT_NOT_FOUND`
+- status guards reject invalid transitions
+- published and archived flows persist the expected state
+- `search` handles province and non-province branches
+- `getWithRealStockByIdAndStatusIsNot` subtracts reserved stock
+- `eventPayout` fails for not-ended events, non-owners, and already-paid events
+
+## First Event Controller Targets
+
+Start with the controller routes that map directly to service branches:
+
+- `GET /api/v1/events`
+- `POST /api/v1/events/{eventId}/admin/publish`
+- `POST /api/v1/events/{eventId}/admin/archive`
+- `PUT /api/v1/events/{eventId}/admin/tags`
+- `POST /api/v1/events`
+- `PUT /api/v1/events/{eventId}`
+- `POST /api/v1/events/{eventId}/archive`
+- `POST /api/v1/events/{eventId}/inactive`
+- `POST /api/v1/events/{eventId}/active`
+- `GET /api/v1/events/organization/{organizationId}`
+- `GET /api/v1/events/organization/{organizationId}/published`
+- `GET /api/v1/events/{eventId}`
+- `GET /api/v1/events/{eventId}/shows`
+- `GET /api/v1/events/public/{eventId}`
+- `GET /api/v1/events/discovery`
+- `GET /api/v1/events/search`
+- `GET /api/v1/events/categories/{categoryId}`
+- `POST /api/v1/events/{eventId}/payout/request`
+
+Keep controller tests focused on:
+
+- request binding
+- status codes
+- response envelopes
+- permission annotations being exercised through mocked auth setup
+
+## Voucher Service Targets
+
+Once the event service/controller base is in place, move to vouchers:
+
+- `getAllByEventId`
+- `getAllPublicByEventId`
+- `createByEventId`
+- `updateByEventId`
+- `deleteByEventId`
+- `getUsage`
+- `getByOrderId`
+- `applyByOrderId`
+- `removeByOrderId`
+
+High-value branches:
+
+- membership authorization failures
+- duplicate voucher code checks
+- voucher usage and per-user limits
+- order not found and voucher not found cases
+- voucher time window validation
+- voucher condition validation
+- applied voucher removal for non-fulfilled orders
+
+## Voucher Controller Targets
+
+Controller routes to cover after the service layer:
+
+- `GET /api/v1/vouchers/{id}/event/{eventId}/usage`
+- `GET /api/v1/vouchers/order/{orderId}`
+- `POST /api/v1/vouchers/order/{orderId}/apply`
+- `POST /api/v1/vouchers/order/{orderId}/remove`
+- `GET /api/v1/vouchers/event/{eventId}`
+- `GET /api/v1/vouchers/event/{eventId}/public`
+- `POST /api/v1/vouchers/event/{eventId}`
+- `PUT /api/v1/vouchers/{id}/event/{eventId}`
+- `DELETE /api/v1/vouchers/{id}/event/{eventId}`
+
+## Suggested File Ownership For Parallel Work
+
+If multiple agents are used in the next session, split by file so work stays isolated:
+
+- Agent 1: `src/test/java/com/ht/eventbox/modules/event/EventServiceTests.java`
+- Agent 2: `src/test/java/com/ht/eventbox/modules/event/EventControllerTests.java`
+- Agent 3: `src/test/java/com/ht/eventbox/modules/event/VoucherServiceTests.java`
+- Agent 4: `src/test/java/com/ht/eventbox/modules/event/VoucherControllerTests.java`
+
+The service tests should be written first. Controller tests can follow once the service fixtures are stable.
+
+## Likely Shared Fixtures
+
+Expect to reuse fixtures for:
+
+- organization owner/member relationships
+- event statuses: `PENDING`, `PUBLISHED`, `DRAFT`, `ARCHIVED`
+- event shows with ended and not-ended time windows
+- tickets with reserved stock and total stock
+- orders with fulfilled totals for payout calculations
+- voucher objects with time windows and usage limits
+
+## Verification
+
+Use the narrowest useful test command while building:
+
+```bash
+./mvnw -Dtest=EventServiceTests,EventControllerTests,VoucherServiceTests,VoucherControllerTests test
+```
+
+If the event module is being built incrementally, run only the files that exist so far.

--- a/docs/organization-test-kickoff.md
+++ b/docs/organization-test-kickoff.md
@@ -1,0 +1,99 @@
+# Organization Test Kickoff
+
+This document is the starting point for the `organization` module test pass.
+
+## Current State
+
+- There are no organization module tests in the current tree.
+- The organization module has one controller and one service:
+  - [src/main/java/com/ht/eventbox/modules/organization/OrganizationController.java](/Users/nguyenduckhaihoan/Working/backend/EventboxServer-SpringBoot-s0ngnguyen/src/main/java/com/ht/eventbox/modules/organization/OrganizationController.java)
+  - [src/main/java/com/ht/eventbox/modules/organization/OrganizationService.java](/Users/nguyenduckhaihoan/Working/backend/EventboxServer-SpringBoot-s0ngnguyen/src/main/java/com/ht/eventbox/modules/organization/OrganizationService.java)
+
+## Recommended Test Order
+
+1. `OrganizationServiceTests`
+2. `OrganizationControllerTests`
+
+Service tests should come first because the organization service contains the ownership checks, Cloudinary side effects, member management, and subscription toggle logic. Controller tests can remain thin and verify mapping, status codes, and response envelopes.
+
+## First Organization Service Targets
+
+Start with the most important and failure-prone service methods:
+
+- `getAll`
+- `getByUserIdAndOrganizationRole`
+- `getByUserId`
+- `getById`
+- `getDetailsById`
+- `create`
+- `update`
+- `deleteById`
+- `addMember`
+- `updateMember`
+- `removeMember`
+- `subscribe`
+
+Suggested first assertions:
+
+- missing organization returns `ORGANIZATION_NOT_FOUND`
+- `getDetailsById` returns subscriber and event counts
+- `create` persists the owner membership and optional logo asset
+- `update` handles logo removal and replacement
+- `deleteById` rejects organizations that still have events
+- `addMember` rejects existing members and missing users
+- `updateMember` rejects users not already in the organization
+- `removeMember` rejects users not already in the organization
+- `subscribe` toggles subscription state and rejects missing user or organization
+
+## First Organization Controller Targets
+
+Start with the controller routes that map directly to service behavior:
+
+- `GET /api/v1/organizations`
+- `GET /api/v1/organizations/me`
+- `GET /api/v1/organizations/me/member`
+- `GET /api/v1/organizations/{id}/details`
+- `GET /api/v1/organizations/{id}`
+- `PUT /api/v1/organizations/{id}`
+- `DELETE /api/v1/organizations/{id}`
+- `POST /api/v1/organizations`
+- `POST /api/v1/organizations/{id}/members`
+- `PUT /api/v1/organizations/{id}/members`
+- `POST /api/v1/organizations/{id}/members/remove`
+- `POST /api/v1/organizations/{id}/subscribe`
+
+Keep controller tests focused on:
+
+- request binding
+- response wrappers
+- status codes
+- permission-gated routes being exercised through mocked auth setup
+
+## Suggested File Ownership For Parallel Work
+
+If multiple agents are used in the next session, split by file so work stays isolated:
+
+- Agent 1: `src/test/java/com/ht/eventbox/modules/organization/OrganizationServiceTests.java`
+- Agent 2: `src/test/java/com/ht/eventbox/modules/organization/OrganizationControllerTests.java`
+
+## Likely Shared Fixtures
+
+Expect to reuse fixtures for:
+
+- organization owner and member relationships
+- organizations with and without assets
+- organizations with and without events
+- users with subscriptions
+- Cloudinary upload and delete results
+- mail side effects for member add/remove flows
+- subscriber and event count lookups
+
+## Verification
+
+Use the narrowest useful test command while building:
+
+```bash
+./mvnw -Dtest=OrganizationServiceTests,OrganizationControllerTests test
+```
+
+If the organization module is being built incrementally, run only the files that exist so far.

--- a/docs/testing-coverage-map.md
+++ b/docs/testing-coverage-map.md
@@ -1,0 +1,125 @@
+# Testing Coverage Map
+
+This document tracks the current test coverage in the repository, grouped by module.
+
+## Auth
+
+Current test file:
+
+- [src/test/java/com/ht/eventbox/modules/auth/AuthControllerTests.java](/Users/nguyenduckhaihoan/Working/backend/EventboxServer-SpringBoot-s0ngnguyen/src/test/java/com/ht/eventbox/modules/auth/AuthControllerTests.java)
+
+Current controller coverage:
+
+- `login` sets access and refresh cookies and returns token payload
+- `refresh` reads the refresh token from cookie and returns new tokens
+- `refresh` returns `INVALID_TOKEN` when the token is missing
+
+Current gaps:
+
+- No auth service test file is present in the current tree
+- No auth validation-failure controller cases are covered yet
+
+## Order
+
+Current test files:
+
+- [src/test/java/com/ht/eventbox/modules/order/OrderServiceTests.java](/Users/nguyenduckhaihoan/Working/backend/EventboxServer-SpringBoot-s0ngnguyen/src/test/java/com/ht/eventbox/modules/order/OrderServiceTests.java)
+- [src/test/java/com/ht/eventbox/modules/order/OrderControllerTests.java](/Users/nguyenduckhaihoan/Working/backend/EventboxServer-SpringBoot-s0ngnguyen/src/test/java/com/ht/eventbox/modules/order/OrderControllerTests.java)
+
+Current service coverage:
+
+- `createReservation` persists an order and reserves tickets
+- `createReservation` rejects sales that have not started
+- `cancelReservation` clears waiting orders
+- `cancelReservation` by order id
+- `getByShowId` rejects users without manager or owner role
+- `createPayment` reuses an existing PayPal session
+- `createPayment` creates a new PayPal order and session
+- `createPayment` rejects a missing order
+- `processPayment` approves and fulfills an active order
+- `processPayment` refunds an expired order
+- `refund` stores a missed-refund audit when PayPal does not return success
+- `refund` persists full refund details and triggers notifications
+- `getByShowId` returns orders for an authorized manager
+- `getByShowId` rejects a missing event
+
+Current controller coverage:
+
+- `createReservation`
+- `createPayment`
+- `cancelReservation`
+- `cancelReservation` by order id
+- `getByShowId`
+- `getByShowId/all`
+- `handlePaypalWebhookCheckout` happy path
+- `handlePaypalWebhookCheckout` invalid webhook path
+- `handlePaypalWebhookPayment` expired-order refund path
+- `handlePaypalWebhookPayment` active-order fulfillment path
+- `handlePaypalWebhookPayment` already-processed skip path
+- `handlePaypalWebhookPayment` invalid webhook path
+
+Current gaps:
+
+- No explicit controller test yet for `getByShowId` unauthorized access
+- No explicit service test yet for the `ORDER_NOT_FOUND` branch inside refund lookup
+- No explicit service test yet for the deprecated `fulfill(long orderId)` overload
+
+Last verified command:
+
+```bash
+./mvnw -Dtest=OrderServiceTests,OrderControllerTests test
+```
+
+Result:
+
+- `26` tests run
+- `0` failures
+- `0` errors
+
+## Event
+
+Current test files:
+
+- None in the current tree
+
+Current coverage:
+
+- No `event` module tests are present yet
+
+Current gaps:
+
+- Controller coverage is missing
+- Service coverage is missing
+- Repository-focused behavior is also unverified
+
+## Organization
+
+Current test files:
+
+- None in the current tree
+
+Current coverage:
+
+- No `organization` module tests are present yet
+
+Current gaps:
+
+- Controller coverage is missing
+- Service coverage is missing
+- Authorization and member-management paths are unverified
+
+## Ticket
+
+Current test files:
+
+- None in the current tree
+
+Current coverage:
+
+- No `ticket` module tests are present yet
+
+Current gaps:
+
+- Controller coverage is missing
+- Service coverage is missing
+- Stock, QR, validation, and reminder flows are unverified

--- a/docs/testing-module-roadmap.md
+++ b/docs/testing-module-roadmap.md
@@ -1,0 +1,23 @@
+# Testing Module Roadmap
+
+This note captures the order we agreed to use when expanding module test coverage.
+
+## Order Of Work
+
+1. `order`
+2. `event`
+3. `organization`
+4. `ticket`
+
+## Why This Order
+
+- `order` is the highest-risk module because it covers reservation state, payment creation, PayPal capture, refund handling, and webhook orchestration.
+- `event` comes next because it tends to sit close to search, publishing, and ticket visibility logic.
+- `organization` follows because it usually drives authorization and management flows.
+- `ticket` comes last because it is often heavily tied to the data already validated by the earlier modules.
+
+## Current Decision
+
+- `order` was the first module expanded.
+- The next session should continue with `event`.
+- If a future bug report changes the priority, keep the same order only if the risk still matches the list above.

--- a/docs/ticket-test-kickoff.md
+++ b/docs/ticket-test-kickoff.md
@@ -1,0 +1,99 @@
+# Ticket Test Kickoff
+
+This document is the starting point for the `ticket` module test pass.
+
+## Current State
+
+- There are no ticket module tests in the current tree.
+- The ticket module has one controller and one service:
+  - [src/main/java/com/ht/eventbox/modules/ticket/TicketController.java](/Users/nguyenduckhaihoan/Working/backend/EventboxServer-SpringBoot-s0ngnguyen/src/main/java/com/ht/eventbox/modules/ticket/TicketController.java)
+  - [src/main/java/com/ht/eventbox/modules/ticket/TicketService.java](/Users/nguyenduckhaihoan/Working/backend/EventboxServer-SpringBoot-s0ngnguyen/src/main/java/com/ht/eventbox/modules/ticket/TicketService.java)
+
+## Recommended Test Order
+
+1. `TicketServiceTests`
+2. `TicketControllerTests`
+
+Service tests should come first because the ticket service contains QR generation, validation rules, trace creation, feedback checks, giveaway flows, reminders, and authorization logic. Controller tests can remain thin and focus on request mapping, status codes, and response payloads.
+
+## First Ticket Service Targets
+
+Start with the highest-risk service methods:
+
+- `getTicketItemsByUserIdAndOrderStatusIs`
+- `getTicketItemsByUserIdAndOrderStatusIn`
+- `getTicketItemById`
+- `getTicketItemQrCode`
+- `validateTicketItem`
+- `createTicketItemTrace`
+- `getTicketItemByShowId`
+- `createTicketItemFeedback`
+- `triggerReminder`
+- `remindUpcomingEvents`
+- `giveawayTicketItem`
+- `getLatestTicketItemFeedbackByOrganizationId`
+- `getTicketItemFeedbackByEventId`
+
+Suggested first assertions:
+
+- missing ticket item returns `TICKET_ITEM_NOT_FOUND`
+- QR code generation rejects tickets before show start and after show end
+- validation rejects invalid or empty QR tokens
+- validation rejects users who are not organization members
+- trace creation alternates between `CHECKED_IN` and `WENT_OUT`
+- show-based queries reject missing events and unauthorized users
+- feedback rejects unused tickets and tickets from unfinished shows
+- reminder flow handles email or push failures without crashing
+- giveaway rejects self-gifting, used tickets, ended shows, and missing recipients
+
+## First Ticket Controller Targets
+
+Start with the controller routes that map directly to service behavior:
+
+- `GET /api/v1/tickets/items/me`
+- `GET /api/v1/tickets/items/{ticketItemId}`
+- `GET /api/v1/tickets/items/{ticketItemId}/qrcode`
+- `POST /api/v1/tickets/validate`
+- `POST /api/v1/tickets/traces`
+- `GET /api/v1/tickets/shows/{showId}/items`
+- `POST /api/v1/tickets/items/{ticketItemId}/feedback`
+- `POST /api/v1/tickets/items/{ticketItemId}/giveaway`
+- `GET /api/v1/tickets/items/feedback/organizations/{organizationId}`
+- `GET /api/v1/tickets/items/feedback/event/{eventId}`
+- `POST /api/v1/tickets/items/{ticketItemId}/reminder/trigger`
+
+Keep controller tests focused on:
+
+- request binding
+- response wrappers
+- status codes
+- permissions on protected endpoints
+
+## Suggested File Ownership For Parallel Work
+
+If multiple agents are used in the next session, split by file so work stays isolated:
+
+- Agent 1: `src/test/java/com/ht/eventbox/modules/ticket/TicketServiceTests.java`
+- Agent 2: `src/test/java/com/ht/eventbox/modules/ticket/TicketControllerTests.java`
+
+## Likely Shared Fixtures
+
+Expect to reuse fixtures for:
+
+- fulfilled and unfulfilled orders
+- ticket items with and without traces
+- event shows before, during, and after the show window
+- organization memberships for validators
+- JWT QR secrets and token generation
+- mail and push notification side effects
+- feedback and giveaway DTOs
+
+## Verification
+
+Use the narrowest useful test command while building:
+
+```bash
+./mvnw -Dtest=TicketServiceTests,TicketControllerTests test
+```
+
+If the ticket module is being built incrementally, run only the files that exist so far.

--- a/src/test/java/com/ht/eventbox/modules/order/OrderControllerTests.java
+++ b/src/test/java/com/ht/eventbox/modules/order/OrderControllerTests.java
@@ -1,0 +1,474 @@
+package com.ht.eventbox.modules.order;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ht.eventbox.config.GlobalExceptionHandler;
+import com.ht.eventbox.constant.Constant;
+import com.ht.eventbox.entities.Order;
+import com.ht.eventbox.entities.Payment;
+import com.ht.eventbox.enums.OrderStatus;
+import com.ht.eventbox.modules.order.dtos.CreateReservationDto;
+import com.ht.eventbox.modules.order.dtos.CreatePaymentDto;
+import com.ht.eventbox.modules.order.dtos.PaymentWebhookDto;
+import com.paypal.sdk.http.response.ApiResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.context.TestPropertySource;
+
+import java.security.PublicKey;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OrderController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Import(GlobalExceptionHandler.class)
+@TestPropertySource(properties = {
+        "paypal.checkout.webhook.id=checkout-webhook",
+        "paypal.payment.webhook.id=payment-webhook"
+})
+class OrderControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private OrderService orderService;
+
+    @MockBean
+    private PayPalService payPalService;
+
+    @MockBean
+    private PaymentService paymentService;
+
+    @MockBean
+    private com.ht.eventbox.filter.JwtService jwtService;
+
+    @MockBean
+    private PublicKey atPublicKey;
+
+    @Test
+    void createReservation_shouldReturnCreatedOrder() throws Exception {
+        var reserveTicket = new CreateReservationDto.ReserveTicketDto();
+        reserveTicket.setTicketId(100L);
+        reserveTicket.setQuantity(1);
+
+        var responseOrder = Order.builder()
+                .id(55L)
+                .status(OrderStatus.WAITING_FOR_PAYMENT)
+                .placeTotal(50000.0)
+                .expiredAt(LocalDateTime.now().plusMinutes(15))
+                .build();
+
+        when(orderService.createReservation(eq(42L), any(CreateReservationDto.class))).thenReturn(responseOrder);
+
+                mockMvc.perform(post("/api/v1/orders/reservation")
+                        .requestAttr("sub", "42")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(CreateReservationDto.builder()
+                                .tickets(java.util.List.of(reserveTicket))
+                                .build())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value(Constant.SuccessCode.UPDATE_SUCCESSFULLY))
+                .andExpect(jsonPath("$.data.id").value(55L))
+                .andExpect(jsonPath("$.data.status").value(OrderStatus.WAITING_FOR_PAYMENT.name()));
+    }
+
+    @Test
+    void cancelReservation_shouldReturnSuccessResponse() throws Exception {
+        when(orderService.cancelReservation(42L)).thenReturn(true);
+
+        mockMvc.perform(post("/api/v1/orders/reservation/cancel")
+                        .requestAttr("sub", "42"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value(Constant.SuccessCode.UPDATE_SUCCESSFULLY))
+                .andExpect(jsonPath("$.data").value(true));
+    }
+
+    @Test
+    void createPayment_shouldReturnPaypalOrder() throws Exception {
+        var paypalOrder = new com.paypal.sdk.models.Order();
+        paypalOrder.setId("paypal-order-9");
+
+        when(orderService.createPayment(eq(42L), any(CreatePaymentDto.class))).thenReturn(paypalOrder);
+
+        mockMvc.perform(post("/api/v1/orders/reservation/payment")
+                        .requestAttr("sub", "42")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(CreatePaymentDto.builder()
+                                .orderId(500L)
+                                .cancelUrl("https://cancel")
+                                .returnUrl("https://return")
+                                .build())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.id").value("paypal-order-9"));
+    }
+
+    @Test
+    void cancelReservationById_shouldReturnSuccessResponse() throws Exception {
+        when(orderService.cancelReservation(42L, 55L)).thenReturn(true);
+
+        mockMvc.perform(post("/api/v1/orders/55/reservation/cancel")
+                        .requestAttr("sub", "42"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value(Constant.SuccessCode.UPDATE_SUCCESSFULLY))
+                .andExpect(jsonPath("$.data").value(true));
+    }
+
+    @Test
+    void getByShowId_shouldReturnOrdersForAuthorizedUser() throws Exception {
+        var order = Order.builder()
+                .id(55L)
+                .status(OrderStatus.FULFILLED)
+                .placeTotal(50000.0)
+                .expiredAt(LocalDateTime.now().plusMinutes(15))
+                .build();
+
+        when(orderService.getByShowId(eq(42L), eq(77L), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(List.of(order));
+
+        mockMvc.perform(get("/api/v1/orders/shows/77")
+                        .requestAttr("sub", "42")
+                        .param("from", "2026-05-15T00:00:00")
+                        .param("to", "2026-05-16T00:00:00")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data[0].id").value(55L));
+    }
+
+    @Test
+    void getByShowIdAll_shouldReturnOrdersForAuthorizedUser() throws Exception {
+        var order = Order.builder()
+                .id(61L)
+                .status(OrderStatus.FULFILLED)
+                .placeTotal(75000.0)
+                .expiredAt(LocalDateTime.now().plusMinutes(15))
+                .build();
+
+        when(orderService.getByShowId(eq(42L), eq(77L))).thenReturn(List.of(order));
+
+        mockMvc.perform(get("/api/v1/orders/shows/77/all")
+                        .requestAttr("sub", "42")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data[0].id").value(61L));
+    }
+
+    @Test
+    void handlePaypalWebhookCheckout_shouldProcessApprovedCheckoutOrder() throws Exception {
+        when(payPalService.verifyWebhook(
+                any(),
+                eq("tx-id"),
+                eq("2026-05-16T00:00:00Z"),
+                eq("sig"),
+                eq("cert"),
+                eq("algo"),
+                eq("checkout-webhook"))).thenReturn(true);
+        doNothing().when(orderService).processPayment(42L, "paypal-order-1");
+
+        String payload = """
+                {
+                  "event_type": "CHECKOUT.ORDER.APPROVED",
+                  "resource": {
+                    "id": "paypal-order-1",
+                    "status": "APPROVED",
+                    "purchase_units": [
+                      {
+                        "custom_id": "42"
+                      }
+                    ]
+                  }
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/orders/paypal/webhook/checkout")
+                        .header("Paypal-Transmission-Id", "tx-id")
+                        .header("Paypal-Transmission-Time", "2026-05-16T00:00:00Z")
+                        .header("Paypal-Transmission-Sig", "sig")
+                        .header("Paypal-Cert-Url", "cert")
+                        .header("Paypal-Auth-Algo", "algo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value(Constant.SuccessCode.PAYPAL_WEBHOOK_HANDLE_SUCCESSFULLY));
+
+        verify(orderService).processPayment(42L, "paypal-order-1");
+    }
+
+    @Test
+    void handlePaypalWebhookCheckout_shouldRejectInvalidWebhook() throws Exception {
+        when(payPalService.verifyWebhook(
+                any(),
+                eq("tx-id"),
+                eq("2026-05-16T00:00:00Z"),
+                eq("sig"),
+                eq("cert"),
+                eq("algo"),
+                eq("checkout-webhook"))).thenReturn(false);
+
+        mockMvc.perform(post("/api/v1/orders/paypal/webhook/checkout")
+                        .header("Paypal-Transmission-Id", "tx-id")
+                        .header("Paypal-Transmission-Time", "2026-05-16T00:00:00Z")
+                        .header("Paypal-Transmission-Sig", "sig")
+                        .header("Paypal-Cert-Url", "cert")
+                        .header("Paypal-Auth-Algo", "algo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value(Constant.ErrorCode.INVALID_PAYPAL_WEBHOOK));
+
+        verifyNoInteractions(orderService);
+    }
+
+    @Test
+    void handlePaypalWebhookPayment_shouldRefundExpiredOrder() throws Exception {
+        var order = Order.builder()
+                .id(500L)
+                .status(OrderStatus.APPROVED)
+                .placeTotal(100000.0)
+                .expiredAt(LocalDateTime.now().minusMinutes(5))
+                .build();
+
+        var paypalOrder = new com.paypal.sdk.models.Order();
+        paypalOrder.setId("paypal-order-2");
+        paypalOrder.setStatus(com.paypal.sdk.models.OrderStatus.COMPLETED);
+        var purchaseUnit = new com.paypal.sdk.models.PurchaseUnit();
+        purchaseUnit.setCustomId("500");
+        paypalOrder.setPurchaseUnits(List.of(purchaseUnit));
+
+        when(payPalService.verifyWebhook(
+                any(),
+                eq("tx-id"),
+                eq("2026-05-16T00:00:00Z"),
+                eq("sig"),
+                eq("cert"),
+                eq("algo"),
+                eq("payment-webhook"))).thenReturn(true);
+        when(payPalService.getOrderById("paypal-order-2"))
+                .thenReturn(new ApiResponse<>(200, null, paypalOrder));
+        when(orderService.findById(500L)).thenReturn(order);
+        when(paymentService.fulfillPaymentFromPaypalOrder(any(PaymentWebhookDto.class), any()))
+                .thenReturn(Payment.builder().id(1L).build());
+        doNothing().when(orderService).refund(eq(order), eq("capture-2"));
+
+        String payload = """
+                {
+                  "event_type": "PAYMENT.CAPTURE.COMPLETED",
+                  "resource": {
+                    "id": "capture-2",
+                    "status": "COMPLETED",
+                    "final_capture": true,
+                    "supplementary_data": {
+                      "related_ids": {
+                        "order_id": "paypal-order-2"
+                      }
+                    }
+                  }
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/orders/paypal/webhook/payment")
+                        .header("Paypal-Transmission-Id", "tx-id")
+                        .header("Paypal-Transmission-Time", "2026-05-16T00:00:00Z")
+                        .header("Paypal-Transmission-Sig", "sig")
+                        .header("Paypal-Cert-Url", "cert")
+                        .header("Paypal-Auth-Algo", "algo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value(Constant.SuccessCode.PAYPAL_WEBHOOK_HANDLE_SUCCESSFULLY));
+
+        verify(paymentService).fulfillPaymentFromPaypalOrder(any(PaymentWebhookDto.class), eq(paypalOrder));
+        verify(orderService).refund(eq(order), eq("capture-2"));
+    }
+
+    @Test
+    void handlePaypalWebhookPayment_shouldFulfillActiveOrder() throws Exception {
+        var order = Order.builder()
+                .id(500L)
+                .status(OrderStatus.APPROVED)
+                .placeTotal(100000.0)
+                .expiredAt(LocalDateTime.now().plusMinutes(15))
+                .build();
+
+        var paypalOrder = new com.paypal.sdk.models.Order();
+        paypalOrder.setId("paypal-order-4");
+        paypalOrder.setStatus(com.paypal.sdk.models.OrderStatus.COMPLETED);
+        var purchaseUnit = new com.paypal.sdk.models.PurchaseUnit();
+        purchaseUnit.setCustomId("500");
+        paypalOrder.setPurchaseUnits(List.of(purchaseUnit));
+
+        when(payPalService.verifyWebhook(
+                any(),
+                eq("tx-id"),
+                eq("2026-05-16T00:00:00Z"),
+                eq("sig"),
+                eq("cert"),
+                eq("algo"),
+                eq("payment-webhook"))).thenReturn(true);
+        when(payPalService.getOrderById("paypal-order-4"))
+                .thenReturn(new ApiResponse<>(200, null, paypalOrder));
+        when(orderService.findById(500L)).thenReturn(order);
+        when(paymentService.fulfillPaymentFromPaypalOrder(any(PaymentWebhookDto.class), any()))
+                .thenReturn(Payment.builder().id(2L).build());
+        when(orderService.fulfill(order)).thenReturn(order);
+        doNothing().when(orderService).onOrderFulfilled(order);
+
+        String payload = """
+                {
+                  "event_type": "PAYMENT.CAPTURE.COMPLETED",
+                  "resource": {
+                    "id": "capture-4",
+                    "status": "COMPLETED",
+                    "final_capture": true,
+                    "supplementary_data": {
+                      "related_ids": {
+                        "order_id": "paypal-order-4"
+                      }
+                    }
+                  }
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/orders/paypal/webhook/payment")
+                        .header("Paypal-Transmission-Id", "tx-id")
+                        .header("Paypal-Transmission-Time", "2026-05-16T00:00:00Z")
+                        .header("Paypal-Transmission-Sig", "sig")
+                        .header("Paypal-Cert-Url", "cert")
+                        .header("Paypal-Auth-Algo", "algo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value(Constant.SuccessCode.PAYPAL_WEBHOOK_HANDLE_SUCCESSFULLY));
+
+        verify(paymentService).fulfillPaymentFromPaypalOrder(any(PaymentWebhookDto.class), eq(paypalOrder));
+        verify(orderService).findById(500L);
+        verify(orderService).fulfill(order);
+        verify(orderService).onOrderFulfilled(order);
+        verifyNoMoreInteractions(orderService);
+    }
+
+    @Test
+    void handlePaypalWebhookPayment_shouldSkipAlreadyProcessedOrder() throws Exception {
+        var order = Order.builder()
+                .id(500L)
+                .status(OrderStatus.FULFILLED)
+                .placeTotal(100000.0)
+                .expiredAt(LocalDateTime.now().minusMinutes(5))
+                .build();
+
+        var paypalOrder = new com.paypal.sdk.models.Order();
+        paypalOrder.setId("paypal-order-3");
+        paypalOrder.setStatus(com.paypal.sdk.models.OrderStatus.COMPLETED);
+        var purchaseUnit = new com.paypal.sdk.models.PurchaseUnit();
+        purchaseUnit.setCustomId("500");
+        paypalOrder.setPurchaseUnits(List.of(purchaseUnit));
+
+        when(payPalService.verifyWebhook(
+                any(),
+                eq("tx-id"),
+                eq("2026-05-16T00:00:00Z"),
+                eq("sig"),
+                eq("cert"),
+                eq("algo"),
+                eq("payment-webhook"))).thenReturn(true);
+        when(payPalService.getOrderById("paypal-order-3"))
+                .thenReturn(new ApiResponse<>(200, null, paypalOrder));
+        when(orderService.findById(500L)).thenReturn(order);
+
+        String payload = """
+                {
+                  "event_type": "PAYMENT.CAPTURE.COMPLETED",
+                  "resource": {
+                    "id": "capture-3",
+                    "status": "COMPLETED",
+                    "final_capture": true,
+                    "supplementary_data": {
+                      "related_ids": {
+                        "order_id": "paypal-order-3"
+                      }
+                    }
+                  }
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/orders/paypal/webhook/payment")
+                        .header("Paypal-Transmission-Id", "tx-id")
+                        .header("Paypal-Transmission-Time", "2026-05-16T00:00:00Z")
+                        .header("Paypal-Transmission-Sig", "sig")
+                        .header("Paypal-Cert-Url", "cert")
+                        .header("Paypal-Auth-Algo", "algo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value(Constant.SuccessCode.PAYPAL_WEBHOOK_HANDLE_SUCCESSFULLY));
+
+        verifyNoInteractions(paymentService);
+        verify(orderService).findById(500L);
+        verifyNoMoreInteractions(orderService);
+    }
+
+    @Test
+    void handlePaypalWebhookPayment_shouldRejectInvalidWebhook() throws Exception {
+        when(payPalService.verifyWebhook(
+                any(),
+                eq("tx-id"),
+                eq("2026-05-16T00:00:00Z"),
+                eq("sig"),
+                eq("cert"),
+                eq("algo"),
+                eq("payment-webhook"))).thenReturn(false);
+
+        mockMvc.perform(post("/api/v1/orders/paypal/webhook/payment")
+                        .header("Paypal-Transmission-Id", "tx-id")
+                        .header("Paypal-Transmission-Time", "2026-05-16T00:00:00Z")
+                        .header("Paypal-Transmission-Sig", "sig")
+                        .header("Paypal-Cert-Url", "cert")
+                        .header("Paypal-Auth-Algo", "algo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value(Constant.ErrorCode.INVALID_PAYPAL_WEBHOOK));
+
+        verifyNoInteractions(orderService, paymentService);
+    }
+}

--- a/src/test/java/com/ht/eventbox/modules/order/OrderServiceTests.java
+++ b/src/test/java/com/ht/eventbox/modules/order/OrderServiceTests.java
@@ -1,0 +1,583 @@
+package com.ht.eventbox.modules.order;
+
+import com.corundumstudio.socketio.BroadcastOperations;
+import com.corundumstudio.socketio.SocketIONamespace;
+import com.corundumstudio.socketio.SocketIOServer;
+import com.ht.eventbox.config.HttpException;
+import com.ht.eventbox.constant.Constant;
+import com.ht.eventbox.entities.Event;
+import com.ht.eventbox.entities.EventShow;
+import com.ht.eventbox.entities.Organization;
+import com.ht.eventbox.entities.Order;
+import com.ht.eventbox.entities.Payment;
+import com.ht.eventbox.entities.PaymentSession;
+import com.ht.eventbox.entities.Ticket;
+import com.ht.eventbox.entities.TicketItem;
+import com.ht.eventbox.entities.User;
+import com.ht.eventbox.entities.UserOrganization;
+import com.ht.eventbox.enums.EventStatus;
+import com.ht.eventbox.enums.OrderStatus;
+import com.ht.eventbox.enums.OrganizationRole;
+import com.ht.eventbox.modules.event.EventRepository;
+import com.ht.eventbox.modules.messaging.PushNotificationService;
+import com.ht.eventbox.modules.ticket.TicketRepository;
+import com.ht.eventbox.modules.mail.MailService;
+import com.ht.eventbox.modules.order.dtos.CreateReservationDto;
+import com.paypal.sdk.http.response.ApiResponse;
+import com.paypal.sdk.models.Money;
+import com.paypal.sdk.models.PayeeBase;
+import com.paypal.sdk.models.OrdersCapture;
+import com.paypal.sdk.models.PaymentCollection;
+import com.paypal.sdk.models.PurchaseUnit;
+import com.paypal.sdk.models.Refund;
+import com.paypal.sdk.models.SellerPayableBreakdown;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTests {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PaymentService paymentService;
+
+    @Mock
+    private PaymentSessionRepository paymentSessionRepository;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private TicketRepository ticketRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private CurrencyConverterServiceV2 currencyConverterService;
+
+    @Mock
+    private PayPalService payPalService;
+
+    @Mock
+    private TicketItemRepository ticketItemRepository;
+
+    @Mock
+    private RefundRepository refundRepository;
+
+    @Mock
+    private MailService mailService;
+
+    @Mock
+    private PushNotificationService pushNotificationService;
+
+    @Mock
+    private SocketIOServer socketIOServer;
+
+    @Spy
+    @InjectMocks
+    private OrderService orderService;
+
+    @Mock
+    private SocketIONamespace eventNamespace;
+
+    @Mock
+    private BroadcastOperations eventBroadcastOperations;
+
+    @Mock
+    private SocketIONamespace orderNamespace;
+
+    @Mock
+    private BroadcastOperations orderBroadcastOperations;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(socketIOServer.getNamespace("/event")).thenReturn(eventNamespace);
+        lenient().when(eventNamespace.getBroadcastOperations()).thenReturn(eventBroadcastOperations);
+        lenient().when(eventNamespace.getRoomOperations(anyString())).thenReturn(eventBroadcastOperations);
+        lenient().when(socketIOServer.getNamespace("/order")).thenReturn(orderNamespace);
+        lenient().when(orderNamespace.getRoomOperations(anyString())).thenReturn(orderBroadcastOperations);
+    }
+
+    @Test
+    void createReservation_shouldPersistOrderAndReserveTickets() {
+        var now = LocalDateTime.now();
+        var ticket = sampleTicket(now.minusHours(1), now.plusHours(2), now.minusHours(2), now.plusHours(1));
+        var reserveTicket = new CreateReservationDto.ReserveTicketDto();
+        reserveTicket.setTicketId(100L);
+        reserveTicket.setQuantity(2);
+        var dto = CreateReservationDto.builder()
+                .tickets(List.of(reserveTicket))
+                .build();
+
+        when(orderRepository.deleteAllByUserIdAndStatusIs(42L, OrderStatus.WAITING_FOR_PAYMENT)).thenReturn(1L);
+        when(ticketRepository.findAllByIdWithLocked(List.of(100L))).thenReturn(List.of(ticket));
+        when(ticketItemRepository.countAllByTicketIdAndOrderStatusInAndOrderExpiredAtIsAfter(
+                eq(100L),
+                anyList(),
+                any())).thenReturn(0L);
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> {
+            Order order = invocation.getArgument(0);
+            order.setId(500L);
+            return order;
+        });
+
+        var savedOrder = orderService.createReservation(42L, dto);
+
+        assertThat(savedOrder.getId()).isEqualTo(500L);
+        assertThat(savedOrder.getStatus()).isEqualTo(OrderStatus.WAITING_FOR_PAYMENT);
+        assertThat(savedOrder.getItems()).hasSize(2);
+        assertThat(savedOrder.getPlaceTotal()).isEqualTo(100000.0);
+        assertThat(savedOrder.getExpiredAt()).isAfter(LocalDateTime.now().minusSeconds(5));
+
+        ArgumentCaptor<Order> orderCaptor = ArgumentCaptor.forClass(Order.class);
+        verify(orderRepository).save(orderCaptor.capture());
+        assertThat(orderCaptor.getValue().getUser().getId()).isEqualTo(42L);
+        verify(orderRepository).deleteAllByUserIdAndStatusIs(42L, OrderStatus.WAITING_FOR_PAYMENT);
+        verify(ticketRepository).findAllByIdWithLocked(List.of(100L));
+        verify(ticketItemRepository).countAllByTicketIdAndOrderStatusInAndOrderExpiredAtIsAfter(
+                eq(100L),
+                anyList(),
+                any());
+    }
+
+    @Test
+    void createReservation_shouldRejectWhenSaleHasNotStarted() {
+        var now = LocalDateTime.now();
+        var ticket = sampleTicket(now.plusHours(1), now.plusHours(3), now.minusHours(2), now.plusHours(2));
+        var reserveTicket = new CreateReservationDto.ReserveTicketDto();
+        reserveTicket.setTicketId(100L);
+        reserveTicket.setQuantity(1);
+        var dto = CreateReservationDto.builder()
+                .tickets(List.of(reserveTicket))
+                .build();
+
+        when(orderRepository.deleteAllByUserIdAndStatusIs(42L, OrderStatus.WAITING_FOR_PAYMENT)).thenReturn(1L);
+        when(ticketRepository.findAllByIdWithLocked(List.of(100L))).thenReturn(List.of(ticket));
+
+        assertThatThrownBy(() -> orderService.createReservation(42L, dto))
+                .isInstanceOf(HttpException.class)
+                .satisfies(throwable -> {
+                    HttpException ex = (HttpException) throwable;
+                    assertThat(ex.getMessage()).isEqualTo(Constant.ErrorCode.TICKET_SALE_NOT_STARTED);
+                    assertThat(ex.getStatus().value()).isEqualTo(400);
+                });
+
+        verify(orderRepository, never()).save(any(Order.class));
+        verify(ticketItemRepository, never()).countAllByTicketIdAndOrderStatusInAndOrderExpiredAtIsAfter(
+                anyLong(), anyList(), any());
+    }
+
+    @Test
+    void cancelReservation_shouldRemoveWaitingOrdersAndReturnTrue() {
+        when(orderRepository.deleteAllByUserIdAndStatusIs(42L, OrderStatus.WAITING_FOR_PAYMENT)).thenReturn(1L);
+
+        boolean result = orderService.cancelReservation(42L);
+
+        assertThat(result).isTrue();
+        verify(orderRepository).deleteAllByUserIdAndStatusIs(42L, OrderStatus.WAITING_FOR_PAYMENT);
+    }
+
+    @Test
+    void cancelReservation_shouldDeleteSpecificOrderAndReturnTrue() {
+        when(orderRepository.deleteByIdAndUserIdAndStatusInAndExpiredAtAfter(
+                eq(500L),
+                eq(42L),
+                eq(List.of(OrderStatus.WAITING_FOR_PAYMENT, OrderStatus.PENDING)),
+                any())).thenReturn(1L);
+
+        boolean result = orderService.cancelReservation(42L, 500L);
+
+        assertThat(result).isTrue();
+        verify(orderRepository).deleteByIdAndUserIdAndStatusInAndExpiredAtAfter(
+                eq(500L),
+                eq(42L),
+                eq(List.of(OrderStatus.WAITING_FOR_PAYMENT, OrderStatus.PENDING)),
+                any());
+    }
+
+    @Test
+    void getByShowId_shouldRejectUsersWithoutManagerOrOwnerRole() {
+        var event = Event.builder()
+                .id(7L)
+                .organization(Organization.builder()
+                        .id(9L)
+                        .userOrganizations(List.of(
+                                UserOrganization.builder()
+                                        .user(User.builder().id(99L).build())
+                                        .role(OrganizationRole.STAFF)
+                                        .build()))
+                        .build())
+                .status(EventStatus.PUBLISHED)
+                .build();
+
+        when(eventRepository.findByShowsId(55L)).thenReturn(Optional.of(event));
+
+        assertThatThrownBy(() -> orderService.getByShowId(42L, 55L, LocalDateTime.now().minusDays(1), LocalDateTime.now()))
+                .isInstanceOf(HttpException.class)
+                .satisfies(throwable -> {
+                    HttpException ex = (HttpException) throwable;
+                    assertThat(ex.getMessage()).isEqualTo(Constant.ErrorCode.NOT_ALLOWED_OPERATION);
+                    assertThat(ex.getStatus().value()).isEqualTo(403);
+                });
+
+        verifyNoInteractions(orderRepository);
+    }
+
+    @Test
+    void createPayment_shouldReuseExistingPaypalOrderWhenSessionExists() throws Exception {
+        var order = sampleOrder();
+        var paymentSession = PaymentSession.builder()
+                .order(order)
+                .provider("paypal")
+                .paypalOrderId("paypal-order-1")
+                .build();
+        var paypalOrder = new com.paypal.sdk.models.Order();
+        paypalOrder.setId("paypal-order-1");
+
+        when(orderRepository.findByIdAndUserIdAndStatusInAndExpiredAtAfter(
+                eq(500L),
+                eq(42L),
+                anyList(),
+                any())).thenReturn(Optional.of(order));
+        when(paymentSessionRepository.findByOrderIdAndProvider(500L, "paypal")).thenReturn(Optional.of(paymentSession));
+        when(payPalService.getOrderById("paypal-order-1")).thenReturn(new ApiResponse<>(200, null, paypalOrder));
+
+        var result = orderService.createPayment(42L, com.ht.eventbox.modules.order.dtos.CreatePaymentDto.builder()
+                .orderId(500L)
+                .cancelUrl("https://cancel")
+                .returnUrl("https://return")
+                .build());
+
+        assertThat(result).isEqualTo(paypalOrder);
+        verify(payPalService).getOrderById("paypal-order-1");
+        verifyNoInteractions(currencyConverterService);
+        verify(orderRepository, never()).save(any(Order.class));
+        verify(paymentSessionRepository, never()).save(any(PaymentSession.class));
+    }
+
+    @Test
+    void createPayment_shouldCreateNewPaypalOrderAndSession() throws Exception {
+        var order = sampleOrder();
+        var paypalOrder = new com.paypal.sdk.models.Order();
+        paypalOrder.setId("paypal-order-2");
+        var apiResponse = new ApiResponse<>(201, null, paypalOrder);
+
+        when(orderRepository.findByIdAndUserIdAndStatusInAndExpiredAtAfter(
+                eq(500L),
+                eq(42L),
+                anyList(),
+                any())).thenReturn(Optional.of(order));
+        when(paymentSessionRepository.findByOrderIdAndProvider(500L, "paypal")).thenReturn(Optional.empty());
+        when(currencyConverterService.convertVndToUsd(100000.0)).thenReturn(4.0);
+        when(payPalService.createOrder(eq("500"), eq(4.0), eq("USD"), anyString(), eq("https://cancel"), eq("https://return")))
+                .thenReturn(apiResponse);
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(paymentSessionRepository.save(any(PaymentSession.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var result = orderService.createPayment(42L, com.ht.eventbox.modules.order.dtos.CreatePaymentDto.builder()
+                .orderId(500L)
+                .cancelUrl("https://cancel")
+                .returnUrl("https://return")
+                .build());
+
+        assertThat(result).isEqualTo(paypalOrder);
+        verify(currencyConverterService).convertVndToUsd(100000.0);
+        verify(orderRepository).save(order);
+        verify(paymentSessionRepository).save(org.mockito.ArgumentMatchers.argThat((PaymentSession session) ->
+                session != null
+                        && "paypal".equals(session.getProvider())
+                        && "paypal-order-2".equals(session.getPaypalOrderId())));
+    }
+
+    @Test
+    void createPayment_shouldRejectMissingOrder() {
+        when(orderRepository.findByIdAndUserIdAndStatusInAndExpiredAtAfter(
+                eq(500L),
+                eq(42L),
+                anyList(),
+                any())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> orderService.createPayment(42L, com.ht.eventbox.modules.order.dtos.CreatePaymentDto.builder()
+                .orderId(500L)
+                .cancelUrl("https://cancel")
+                .returnUrl("https://return")
+                .build()))
+                .isInstanceOf(HttpException.class)
+                .satisfies(throwable -> {
+                    HttpException ex = (HttpException) throwable;
+                    assertThat(ex.getMessage()).isEqualTo(Constant.ErrorCode.ORDER_NOT_FOUND);
+                    assertThat(ex.getStatus().value()).isEqualTo(404);
+                });
+
+        verify(orderRepository).findByIdAndUserIdAndStatusInAndExpiredAtAfter(
+                eq(500L),
+                eq(42L),
+                anyList(),
+                any());
+        verifyNoInteractions(paymentSessionRepository, payPalService, currencyConverterService);
+    }
+
+    @Test
+    void processPayment_shouldApproveAndFulfillActiveOrder() throws Exception {
+        var order = sampleOrder();
+        order.setStatus(OrderStatus.PENDING);
+        order.setExpiredAt(LocalDateTime.now().plusMinutes(15));
+
+        var paypalOrder = new com.paypal.sdk.models.Order();
+        paypalOrder.setId("paypal-order-3");
+        paypalOrder.setStatus(com.paypal.sdk.models.OrderStatus.COMPLETED);
+        paypalOrder.setPurchaseUnits(List.of(purchaseUnit("42", "capture-1")));
+        var capture = new OrdersCapture();
+        capture.setId("capture-1");
+        capture.setFinalCapture(true);
+        capture.setAmount(new Money("USD", "100.00"));
+        var paymentCollection = new PaymentCollection();
+        paymentCollection.setCaptures(List.of(capture));
+        paypalOrder.getPurchaseUnits().get(0).setPayments(paymentCollection);
+
+        when(orderRepository.findById(500L)).thenReturn(Optional.of(order));
+        when(payPalService.captureOrder("paypal-order-3")).thenReturn(new ApiResponse<>(200, null, paypalOrder));
+        doNothing().when(orderService).onOrderApproved(any(Order.class));
+        doNothing().when(orderService).onOrderFulfilled(any(Order.class));
+        doReturn(order).when(orderService).fulfill(any(Order.class));
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        orderService.processPayment(500L, "paypal-order-3");
+
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.APPROVED);
+        verify(paymentService).createFromOrderAndPaypalOrder(order, paypalOrder);
+        verify(paymentService).fulfillPaymentFromPaypalOrder(capture, paypalOrder);
+        verify(orderRepository).save(order);
+        verify(orderService).fulfill(order);
+    }
+
+    @Test
+    void processPayment_shouldRefundExpiredOrder() throws Exception {
+        var order = sampleOrder();
+        order.setStatus(OrderStatus.PENDING);
+        order.setExpiredAt(LocalDateTime.now().minusMinutes(5));
+
+        var paypalOrder = new com.paypal.sdk.models.Order();
+        paypalOrder.setId("paypal-order-4");
+        paypalOrder.setStatus(com.paypal.sdk.models.OrderStatus.COMPLETED);
+        paypalOrder.setPurchaseUnits(List.of(purchaseUnit("42", "capture-2")));
+        var capture = new OrdersCapture();
+        capture.setId("capture-2");
+        capture.setFinalCapture(true);
+        capture.setAmount(new Money("USD", "100.00"));
+        var paymentCollection = new PaymentCollection();
+        paymentCollection.setCaptures(List.of(capture));
+        paypalOrder.getPurchaseUnits().get(0).setPayments(paymentCollection);
+
+        when(orderRepository.findById(500L)).thenReturn(Optional.of(order));
+        when(payPalService.captureOrder("paypal-order-4")).thenReturn(new ApiResponse<>(200, null, paypalOrder));
+        doNothing().when(orderService).onOrderApproved(any(Order.class));
+        doNothing().when(orderService).refund(any(Order.class), eq("capture-2"));
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        orderService.processPayment(500L, "paypal-order-4");
+
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.PENDING);
+        verify(orderService).refund(order, "capture-2");
+    }
+
+    @Test
+    void refund_shouldSaveMissedRefundWhenPaypalDoesNotReturnSuccess() throws Exception {
+        var payment = Payment.builder()
+                .id(1L)
+                .paypalCaptureId("capture-1")
+                .order(sampleOrder())
+                .build();
+        var order = sampleOrder();
+        order.setId(500L);
+
+        when(paymentRepository.findByPaypalCaptureId("capture-1")).thenReturn(Optional.of(payment));
+        when(payPalService.refundCapture(eq("capture-1"), anyString()))
+                .thenReturn(new ApiResponse<>(500, null, new Refund()));
+
+        orderService.refund(order, "capture-1");
+
+        verify(refundRepository).save(org.mockito.ArgumentMatchers.argThat((com.ht.eventbox.entities.Refund refund) ->
+                refund != null
+                        && "MISSED".equals(refund.getStatus())));
+    }
+
+    @Test
+    void refund_shouldPersistFullRefundDetailsAndTriggerNotifications() throws Exception {
+        var order = sampleOrder();
+        order.setStatus(OrderStatus.FULFILLED);
+        var payment = Payment.builder()
+                .id(1L)
+                .paypalCaptureId("capture-2")
+                .order(order)
+                .build();
+
+        when(paymentRepository.findByPaypalCaptureId("capture-2")).thenReturn(Optional.of(payment));
+        when(payPalService.refundCapture(eq("capture-2"), anyString()))
+                .thenReturn(new ApiResponse<>(200, null, sampleRefund()));
+
+        orderService.refund(order, "capture-2");
+
+        verify(refundRepository).save(org.mockito.ArgumentMatchers.argThat((com.ht.eventbox.entities.Refund refund) ->
+                refund != null
+                        && "COMPLETED".equals(refund.getStatus())
+                        && "refund-1".equals(refund.getPaypalRefundId())
+                        && "capture-2".equals(refund.getPayment().getPaypalCaptureId())
+                        && "REF-123".equals(refund.getPayerMerchantId())
+                        && "payer@example.com".equals(refund.getPayerEmail())));
+    }
+
+    @Test
+    void getByShowId_shouldReturnOrdersForAuthorizedManager() {
+        var event = Event.builder()
+                .id(7L)
+                .organization(Organization.builder()
+                        .id(9L)
+                        .userOrganizations(List.of(
+                                UserOrganization.builder()
+                                        .user(User.builder().id(42L).build())
+                                        .role(OrganizationRole.MANAGER)
+                                        .build()))
+                        .build())
+                .status(EventStatus.PUBLISHED)
+                .build();
+        var order = sampleOrder();
+
+        when(eventRepository.findByShowsId(55L)).thenReturn(Optional.of(event));
+        when(orderRepository.findAllByItemsTicketEventShowIdAndStatusIsAndFulfilledAtBetween(
+                eq(55L), eq(OrderStatus.FULFILLED), any(), any())).thenReturn(List.of(order));
+
+        var result = orderService.getByShowId(42L, 55L, LocalDateTime.now().minusDays(1), LocalDateTime.now());
+
+        assertThat(result).containsExactly(order);
+        verify(orderRepository).findAllByItemsTicketEventShowIdAndStatusIsAndFulfilledAtBetween(
+                eq(55L), eq(OrderStatus.FULFILLED), any(), any());
+    }
+
+    @Test
+    void getByShowId_shouldRejectMissingEvent() {
+        when(eventRepository.findByShowsId(55L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> orderService.getByShowId(42L, 55L, LocalDateTime.now().minusDays(1), LocalDateTime.now()))
+                .isInstanceOf(HttpException.class)
+                .satisfies(throwable -> {
+                    HttpException ex = (HttpException) throwable;
+                    assertThat(ex.getMessage()).isEqualTo(Constant.ErrorCode.EVENT_NOT_FOUND);
+                    assertThat(ex.getStatus().value()).isEqualTo(404);
+                });
+    }
+
+    private Ticket sampleTicket(LocalDateTime saleStartTime, LocalDateTime saleEndTime,
+                                LocalDateTime startTime, LocalDateTime endTime) {
+        return Ticket.builder()
+                .id(100L)
+                .price(50000.0)
+                .stock(10)
+                .initialStock(10)
+                .available(true)
+                .eventShow(EventShow.builder()
+                        .id(200L)
+                        .event(Event.builder().id(7L).build())
+                        .saleStartTime(saleStartTime)
+                        .saleEndTime(saleEndTime)
+                        .startTime(startTime)
+                        .endTime(endTime)
+                        .title("Sample Show")
+                        .build())
+                .build();
+    }
+
+    private Order sampleOrder() {
+        var event = Event.builder().id(7L).build();
+        var eventShow = EventShow.builder().id(200L).event(event).build();
+        var ticket = Ticket.builder()
+                .id(100L)
+                .price(50000.0)
+                .stock(10)
+                .initialStock(10)
+                .available(true)
+                .eventShow(eventShow)
+                .build();
+        var ticketItem = TicketItem.builder()
+                .ticket(ticket)
+                .placeTotal(50000.0)
+                .build();
+        return Order.builder()
+                .id(500L)
+                .user(User.builder().id(42L).email("user@example.com").firstName("Test").lastName("User").build())
+                .status(OrderStatus.WAITING_FOR_PAYMENT)
+                .placeTotal(100000.0)
+                .items(new ArrayList<>(List.of(ticketItem)))
+                .expiredAt(LocalDateTime.now().plusMinutes(15))
+                .build();
+    }
+
+    private PurchaseUnit purchaseUnit(String customId, String captureId) {
+        var purchaseUnit = new PurchaseUnit();
+        purchaseUnit.setCustomId(customId);
+        var paymentCollection = new PaymentCollection();
+        var capture = new OrdersCapture();
+        capture.setId(captureId);
+        capture.setFinalCapture(true);
+        capture.setAmount(new Money("USD", "100.00"));
+        paymentCollection.setCaptures(List.of(capture));
+        purchaseUnit.setPayments(paymentCollection);
+        return purchaseUnit;
+    }
+
+    private Refund sampleRefund() {
+        var refund = new Refund();
+        refund.setId("refund-1");
+        refund.setStatus(com.paypal.sdk.models.RefundStatus.COMPLETED);
+        refund.setCustomId("42");
+        refund.setCreateTime("2026-05-16T00:00:00Z");
+        refund.setUpdateTime("2026-05-16T00:10:00Z");
+        refund.setNoteToPayer("Refund for order #500 due to late payment");
+        refund.setAcquirerReferenceNumber("ARN-1");
+        refund.setAmount(new Money("USD", "100.00"));
+        var payer = new PayeeBase();
+        payer.setEmailAddress("payer@example.com");
+        payer.setMerchantId("REF-123");
+        refund.setPayer(payer);
+
+        var breakdown = new SellerPayableBreakdown();
+        breakdown.setGrossAmount(new Money("USD", "100.00"));
+        breakdown.setNetAmount(new Money("USD", "95.00"));
+        breakdown.setPaypalFee(new Money("USD", "5.00"));
+        breakdown.setTotalRefundedAmount(new Money("USD", "100.00"));
+        refund.setSellerPayableBreakdown(breakdown);
+        return refund;
+    }
+}


### PR DESCRIPTION
Add durable handoff docs for testing strategy and current module coverage.

Include kickoff guides for event, organization, and ticket so the next session can start independently. Keep the expanded order test coverage and its verification history together with the docs.